### PR TITLE
drop v11 support; add internal sharding again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # BLAPI - the BotListAPI
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/aebcf7d4333d483cb1b66d3d79ffff5f)](https://www.codacy.com/manual/T0TProduction/BLAPI?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=T0TProduction/BLAPI&amp;utm_campaign=Badge_Grade) [![npm downloads](https://img.shields.io/npm/dt/blapi.svg)](https://nodei.co/npm/blapi/) [![install size](https://packagephobia.now.sh/badge?p=blapi)](https://packagephobia.now.sh/result?p=blapi) 
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/aebcf7d4333d483cb1b66d3d79ffff5f)](https://www.codacy.com/manual/T0TProduction/BLAPI?utm_source=github.com&utm_medium=referral&utm_content=T0TProduction/BLAPI&utm_campaign=Badge_Grade) [![npm downloads](https://img.shields.io/npm/dt/blapi.svg)](https://nodei.co/npm/blapi/) [![install size](https://packagephobia.now.sh/badge?p=blapi)](https://packagephobia.now.sh/result?p=blapi)
 [![dependencies Status](https://david-dm.org/T0TProduction/BLAPI/status.svg)](https://david-dm.org/T0TProduction/BLAPI) [![jsDelivr](https://data.jsdelivr.com/v1/package/npm/blapi/badge?style=rounded)](https://www.jsdelivr.com/package/npm/blapi)
 
 [![nodei](https://nodei.co/npm/blapi.png)](https://nodei.co/npm/blapi/)
 
 BLAPI is a package to handle posting your discord bot stats to botlists. Now typed and ready to be used in your Typescript powered bots!
 
-It's intended to be used with discord.js, though you can also manually post your stats.
+It's intended to be used with discord.js v12, though you can also manually post your stats.
 
-BLAPI fully supports external [and temporarily disabled: discord.js internal] sharding with and without the use of the [BotBlock API](https://botblock.org/api/docs#count).
+BLAPI fully supports external and discord.js internal sharding with and without the use of the [BotBlock API](https://botblock.org/api/docs#count).
 
 ## Installation
 
@@ -33,8 +33,8 @@ The list of all supported bot lists and their respective names for the apiKeys o
 
 ```js
 // ES6
-import * as blapi from "blapi"; 
-// or 
+import * as blapi from "blapi";
+// or
 import { handle } from "blapi"; // Just the functions you want to use
 // or commonJS
 const blapi = require("blapi");
@@ -84,7 +84,7 @@ The JSON object which includes all the API keys should look like this:
 ```json
 {
   "bot list domain": "API key for that bot list",
-  "bot list domain": "API key for that bot list",
+  "bot list domain": "API key for that bot list"
 }
 ```
 
@@ -99,7 +99,7 @@ an example would be:
 
 ## Lists
 
-A list of supported bot lists can be found [here](https://github.com/botblock/BLAPI/blob/master/src/fallbackListData.ts). 
+A list of supported bot lists can be found [here](https://github.com/botblock/BLAPI/blob/master/src/fallbackListData.ts).
 Supported legacy Ids can be found [here](https://github.com/botblock/BLAPI/blob/master/src/legacyIdsFallbackData.ts).
 
 BLAPI will look for new additions on startup via the [BotBlock API](https://botblock.org/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "blapi",
-  "version": "1.3.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1618,9 +1618,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -2113,7 +2113,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -2167,7 +2167,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -2607,7 +2607,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -3011,7 +3011,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -3047,9 +3047,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "files": [
     "dist/"
   ],
-  "version": "1.3.3",
+  "version": "2.0.0",
   "dependencies": {
     "node-fetch": "^2.6.0"
   }

--- a/src/blapi.ts
+++ b/src/blapi.ts
@@ -219,9 +219,7 @@ async function handleInternal(
         console.error('BLAPI: Error while fetching shard server counts:', e);
       }
       // Checks if bot is sharded with internal sharding
-    } else if (
-      /* client.ws && client.ws.shards && */ client.ws.shards.size > 1
-    ) {
+    } else if (client.ws.shards.size > 1) {
       shard_count = client.ws.shards.size;
       // Get array of shards, loosing collection typings make this somewhat ugly
       shards = client.ws.shards.map(

--- a/src/blapi.ts
+++ b/src/blapi.ts
@@ -26,7 +26,7 @@ type apiKeysObject = { [listname: string]: string };
  * to make BLAPI compatible with typescript code that does not use discord.js
  */
 class Collection<K, T> extends Map<K, T> {
-  /* [key: string]: any; */
+  [key: string]: any;
 }
 
 /**
@@ -217,23 +217,19 @@ async function handleInternal(
       /* client.ws && client.ws.shards && */ client.ws.shards.size > 1
     ) {
       shard_count = client.ws.shards.size;
-      // Get array of shards
-      const shardCounts: Array<number> = [];
-      client.ws.shards.forEach((shard) => {
-        let count = 0;
-        client.guilds.cache.forEach((g) => {
-          if (g.shardID === shard.id) count++;
-        });
-        shardCounts.push(count);
-      });
-      if (shardCounts.length !== client.ws.shards.size) {
+      // Get array of shards, loosing collection typings make this somewhat ugly
+      shards = client.ws.shards.map(
+        (s: { id: number }) => client.guilds.cache.filter(
+          (g: { shardID: number }) => g.shardID === s.id,
+        ).size,
+      ) as Array<number>;
+      if (shards.length !== client.ws.shards.size) {
         // If not all shards are up yet, we skip this run of handleInternal
         console.log(
           "BLAPI: Not all shards are up yet, so we're skipping this run.",
         );
         return;
       }
-      shards = shardCounts;
       server_count = shards.reduce(
         (prev: number, val: number) => prev + val,
         0,

--- a/src/blapi.ts
+++ b/src/blapi.ts
@@ -219,7 +219,9 @@ async function handleInternal(
         console.error('BLAPI: Error while fetching shard server counts:', e);
       }
       // Checks if bot is sharded with internal sharding
-    } else if (client.ws && client.ws.shards && client.ws.shards.size > 0) {
+    } else if (
+      /* client.ws && client.ws.shards && */ client.ws.shards.size > 1
+    ) {
       shard_count = client.ws.shards.size;
       // Get array of shards
       const shardCounts: Array<number> = [];


### PR DESCRIPTION
since the TS rewrite and discord.js updating to v12, this had been deactivated.
currently, I've updated the types to mirror v12 and readded the adjusted logic, but I'm not sure about:

- how does v12 handle non-sharding? ws and ws.shards seem to always be defined
- what did v11 do differently, and do we want to support it?

@advaith1 since you added the original support for internal sharding, maybe you could take a look at it as well?