### PR TITLE
fix: stringify headers logging

### DIFF
--- a/src/requests.ts
+++ b/src/requests.ts
@@ -27,7 +27,6 @@ export async function post(
     if (logStuff) {
       logger.info(` posted to ${apiPath}`);
       logger.info(` statusCode: ${response.statusCode}`);
-      // stringify it since it's an object, doesn't need to be pretty
       logger.info(` headers: ${JSON.stringify(response.headers)}`);
       // it's text because text accepts both json and plain text, while json only supports json
       logger.info(` data: ${await response.text()}`);

--- a/src/requests.ts
+++ b/src/requests.ts
@@ -27,7 +27,8 @@ export async function post(
     if (logStuff) {
       logger.info(` posted to ${apiPath}`);
       logger.info(` statusCode: ${response.statusCode}`);
-      logger.info(` headers: ${response.headers}`);
+      // stringify it since it's an object, doesn't need to be pretty
+      logger.info(` headers: ${JSON.stringify(response.headers)}`);
       // it's text because text accepts both json and plain text, while json only supports json
       logger.info(` data: ${await response.text()}`);
     }


### PR DESCRIPTION
I noticed it shows `[object Object]` and not the actual headers.

![image](https://user-images.githubusercontent.com/10573728/193425935-5a8c180f-59b9-4086-97a5-2dc1a1bad6ff.png)
